### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add `Denpa\Bitcoin\Providers\ServiceProvider::class,` line to the providers list
 ```
 
 Publish config file by running
-`php artisan vendor:publish --provider="Denpa\Bitcoin\ServiceProvider"` in your project directory.
+`php artisan vendor:publish --provider="Denpa\Bitcoin\Providers\ServiceProvider"` in your project directory.
 
 You might also want to add facade to $aliases array in /config/app.php.
 ```php


### PR DESCRIPTION
At vendor publish command line, `Providers` is missing in Command
```
php artisan vendor:publish --provider="Denpa\Bitcoin\Providers\ServiceProvider"
```