### PR TITLE
Don't use Illuminate Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     ],
     "require": {
         "php": ">=7.1",
-        "illuminate/support": "5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
         "denpa/php-bitcoinrpc": "^2.1"
     },
     "require-dev": {


### PR DESCRIPTION
The user can’t upgrade to the next version until you (and every other package using illuminate/support) release a new version. Now your framework agnostic package is preventing the user from updating their framework. (https://mattallan.org/posts/dont-use-illuminate-support/)